### PR TITLE
SNAPSHOT is not present in sonatype nexus

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ In case of Maven, for example, add the following lines to your `dependencies` co
 <dependency>
     <groupId>com.javax0.yamaledt</groupId>
     <artifactId>yamaledt</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <scope>test</scope>
 </dependency>
 ----


### PR DESCRIPTION
Just a minor update in the README, great work @verhas !